### PR TITLE
ffmpeg: ignore extra data streams with `-dn` (closes #2)

### DIFF
--- a/youtube_dlc/postprocessor/embedthumbnail.py
+++ b/youtube_dlc/postprocessor/embedthumbnail.py
@@ -96,7 +96,7 @@ class EmbedThumbnailPP(FFmpegPostProcessor):
             os.rename(encodeFilename(old_thumbnail_filename), encodeFilename(thumbnail_filename))
 
             options = [
-                '-c', 'copy', '-map', '0',
+                '-c', 'copy', '-map', '0', '-dn',
                 '-attach', thumbnail_filename, '-metadata:s:t', 'mimetype=image/jpeg']
 
             self._downloader.to_screen('[ffmpeg] Adding thumbnail to "%s"' % filename)

--- a/youtube_dlc/postprocessor/ffmpeg.py
+++ b/youtube_dlc/postprocessor/ffmpeg.py
@@ -359,7 +359,7 @@ class FFmpegVideoRemuxerPP(FFmpegPostProcessor):
         if information['ext'] == self._preferedformat:
             self._downloader.to_screen('[ffmpeg] Not remuxing video file %s - already is in target format %s' % (path, self._preferedformat))
             return [], information
-        options = ['-c', 'copy', '-map', '0']
+        options = ['-c', 'copy', '-map', '0', '-dn']
         prefix, sep, ext = path.rpartition('.')
         outpath = prefix + sep + self._preferedformat
         self._downloader.to_screen('[' + 'ffmpeg' + '] Remuxing video from %s to %s, Destination: ' % (information['ext'], self._preferedformat) + outpath)
@@ -428,7 +428,7 @@ class FFmpegEmbedSubtitlePP(FFmpegPostProcessor):
         input_files = [filename] + sub_filenames
 
         opts = [
-            '-c', 'copy', '-map', '0',
+            '-c', 'copy', '-map', '0', '-dn',
             # Don't copy the existing subtitles, we may be running the
             # postprocessor a second time
             '-map', '-0:s',
@@ -498,7 +498,7 @@ class FFmpegMetadataPP(FFmpegPostProcessor):
         filename = info['filepath']
         temp_filename = prepend_extension(filename, 'temp')
         in_filenames = [filename]
-        options = ['-map', '0']
+        options = ['-map', '0', '-dn']
 
         if info['ext'] == 'm4a':
             options.extend(['-vn', '-acodec', 'copy'])
@@ -578,7 +578,7 @@ class FFmpegFixupStretchedPP(FFmpegPostProcessor):
         filename = info['filepath']
         temp_filename = prepend_extension(filename, 'temp')
 
-        options = ['-c', 'copy', '-map', '0', '-aspect', '%f' % stretched_ratio]
+        options = ['-c', 'copy', '-map', '0', '-dn', '-aspect', '%f' % stretched_ratio]
         self._downloader.to_screen('[ffmpeg] Fixing aspect ratio in "%s"' % filename)
         self.run_ffmpeg(filename, temp_filename, options)
 
@@ -596,7 +596,7 @@ class FFmpegFixupM4aPP(FFmpegPostProcessor):
         filename = info['filepath']
         temp_filename = prepend_extension(filename, 'temp')
 
-        options = ['-c', 'copy', '-map', '0', '-f', 'mp4']
+        options = ['-c', 'copy', '-map', '0', '-dn', '-f', 'mp4']
         self._downloader.to_screen('[ffmpeg] Correcting container in "%s"' % filename)
         self.run_ffmpeg(filename, temp_filename, options)
 
@@ -612,7 +612,7 @@ class FFmpegFixupM3u8PP(FFmpegPostProcessor):
         if self.get_audio_codec(filename) == 'aac':
             temp_filename = prepend_extension(filename, 'temp')
 
-            options = ['-c', 'copy', '-map', '0', '-f', 'mp4', '-bsf:a', 'aac_adtstoasc']
+            options = ['-c', 'copy', '-map', '0', '-dn', '-f', 'mp4', '-bsf:a', 'aac_adtstoasc']
             self._downloader.to_screen('[ffmpeg] Fixing malformed AAC bitstream in "%s"' % filename)
             self.run_ffmpeg(filename, temp_filename, options)
 


### PR DESCRIPTION
Sometimes, video files will arrive with a timecode data stream
that causes `-map 0` to error out due to the stream not being
supported in the output container. These data streams generally do
not matter, so tell ffmpeg to ignore them rather than choking on
them.